### PR TITLE
支持array格式的上报处理，强制编译编码为UTF8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <name>AmazingBot</name>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <res>${project.basedir}/resources/</res>
     </properties>
 

--- a/src/me/albert/amazingbot/bot/BotEventParser.java
+++ b/src/me/albert/amazingbot/bot/BotEventParser.java
@@ -2,6 +2,8 @@ package me.albert.amazingbot.bot;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonArray;
 import me.albert.amazingbot.events.ABEvent;
 import me.albert.amazingbot.events.message.GroupMessageEvent;
 import me.albert.amazingbot.events.message.MessageReceiveEvent;
@@ -45,6 +47,18 @@ public class BotEventParser {
     }
 
     public <T extends ABEvent> T parse(Class<T> eventClass) {
+        JsonElement messageElement = object.get("message");
+        if (messageElement != null && messageElement.isJsonArray()) {
+            JsonArray messageArray = messageElement.getAsJsonArray();
+            StringBuilder messageBuilder = new StringBuilder();
+            for (JsonElement element : messageArray) {
+                JsonObject messageObject = element.getAsJsonObject();
+                JsonObject dataObject = messageObject.get("data").getAsJsonObject();
+                String text = dataObject.get("text").getAsString();
+                messageBuilder.append(text);
+            }
+            object.addProperty("message", messageBuilder.toString());
+        }
         return gson.fromJson(object, eventClass);
     }
 


### PR DESCRIPTION
**为什么要支持array格式上报**
因为我所使用的机器人框架不支持string格式上报，而不支持array格式就意味着插件无法处理来自QQ的消息，只能单方面向框架发送请求

**为什么要强制使用UTF-8**
因为我使用windows+vscode编译的时候GBK编码无法处理资源文件，编译失败，故添加